### PR TITLE
Fixed choppiness of player movement.

### DIFF
--- a/game/game.cc
+++ b/game/game.cc
@@ -19,7 +19,8 @@ bool Game::Init() {
     return false;
   }
 
-  renderer_ = SDL_CreateRenderer(window_, -1, 0);
+  renderer_ = SDL_CreateRenderer(
+      window_, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
   if (!renderer_) {
     return false;
   }
@@ -48,38 +49,22 @@ void Game::HandleEvents() {
       case SDL_QUIT:
         is_running_ = false;
         break;
-        // case SDL_KEYDOWN:
-        //   switch (event_.key.keysym.sym) {
-        //     case SDLK_w:
-        //       player_->Move(entities::Player::Direction::kUp);
-        //       break;
-        //     case SDLK_a:
-        //       player_->Move(entities::Player::Direction::kLeft);
-        //       break;
-        //     case SDLK_s:
-        //       player_->Move(entities::Player::Direction::kDown);
-        //       break;
-        //     case SDLK_d:
-        //       player_->Move(entities::Player::Direction::kRight);
-        //       break;
-        //   }
-        //   break;
     }
+  }
 
-    const Uint8* keystate = SDL_GetKeyboardState(NULL);
+  const Uint8* keystate = SDL_GetKeyboardState(NULL);
 
-    if (keystate[SDL_SCANCODE_W]) {
-      player_->Move(entities::Player::Direction::kUp);
-    }
-    if (keystate[SDL_SCANCODE_A]) {
-      player_->Move(entities::Player::Direction::kLeft);
-    }
-    if (keystate[SDL_SCANCODE_S]) {
-      player_->Move(entities::Player::Direction::kDown);
-    }
-    if (keystate[SDL_SCANCODE_D]) {
-      player_->Move(entities::Player::Direction::kRight);
-    }
+  if (keystate[SDL_SCANCODE_W]) {
+    player_->Move(entities::Player::Direction::kUp);
+  }
+  if (keystate[SDL_SCANCODE_A]) {
+    player_->Move(entities::Player::Direction::kLeft);
+  }
+  if (keystate[SDL_SCANCODE_S]) {
+    player_->Move(entities::Player::Direction::kDown);
+  }
+  if (keystate[SDL_SCANCODE_D]) {
+    player_->Move(entities::Player::Direction::kRight);
   }
 }
 

--- a/game/game.h
+++ b/game/game.h
@@ -34,8 +34,6 @@ class Game {
   SDL_Event event_;
   bool is_running_ = false;
   entities::Player* player_ = nullptr;
-  const int fps_ = 60;
-  const int ticks_per_frame_ = 1000 / fps_;
 
   Game() = default;
   Game(const Game& game) = delete;

--- a/main/bullet_hell_main.cc
+++ b/main/bullet_hell_main.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #include "SDL2/SDL.h"
-// #include "absl/flags/flag.h"
+#include "absl/flags/flag.h"
 #include "game/game.h"
 #include "absl/flags/flag.h"
 


### PR DESCRIPTION
The chopiness of the player movement was due do the keyboard state being registered inside the SDL_Event if statement.

Fixes #7