### PR TITLE
Fixing player movement by normalizing diagonal movement.

### DIFF
--- a/entities/BUILD
+++ b/entities/BUILD
@@ -1,10 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
-    name = "ben_forward_face_png",
-    srcs = ["ben_forward_face.png"],
-)
-
 cc_library(
     name = "entity_cc",
     srcs = ["entity.cc"],

--- a/entities/BUILD
+++ b/entities/BUILD
@@ -19,6 +19,7 @@ cc_library(
     data = ["//assets/player:player_asset"],
     deps = [
         "//entities:entity_cc",
+        "//math:vector_cc",
         "@sdl2",
     ],
 )

--- a/entities/entity.h
+++ b/entities/entity.h
@@ -9,12 +9,14 @@ class Entity {
  public:
   virtual ~Entity() = default;
 
+  enum Direction { kNone, kUp, kDown, kLeft, kRight };
+
   SDL_FPoint GetPosition() const;
   float GetWidth() const;
   float GetHeight() const;
+  virtual void Move(Direction dir) = 0;
   virtual void Update() = 0;
   virtual void Render() = 0;
-  virtual int GenerateID() const = 0;
 
  protected:
   SDL_Renderer* renderer_;
@@ -25,7 +27,6 @@ class Entity {
   SDL_Texture* texture_;
   SDL_Rect src_rect_;
   SDL_FRect dest_rect_;
-  int id_;
 };
 
 }  // namespace entities

--- a/entities/entity.h
+++ b/entities/entity.h
@@ -14,7 +14,6 @@ class Entity {
   SDL_FPoint GetPosition() const;
   float GetWidth() const;
   float GetHeight() const;
-  virtual void Move(Direction dir) = 0;
   virtual void Update() = 0;
   virtual void Render() = 0;
 

--- a/entities/player.cc
+++ b/entities/player.cc
@@ -1,7 +1,10 @@
 #include "entities/player.h"
 
+#include <iostream>
+
 #include "SDL2/SDL.h"
 #include "SDL2/SDL_image.h"
+#include "math/vector.h"
 
 namespace entities {
 
@@ -13,7 +16,6 @@ Player::Player(SDL_Renderer* renderer) {
   width_ = 100;
   height_ = 100;
   speed_ = 5;
-  id_ = GenerateID();
 
   UpdateRect();
 }
@@ -23,22 +25,22 @@ void Player::HandleMovement(int screen_width, int screen_height) {
 
   if (keystate[SDL_SCANCODE_W]) {
     if (position_.y - speed_ >= 0) {
-      Move(entities::Player::Direction::kUp);
+      Move(Direction::kUp);
     }
   }
   if (keystate[SDL_SCANCODE_A]) {
     if (position_.x - speed_ >= 0) {
-      Move(entities::Player::Direction::kLeft);
+      Move(Direction::kLeft);
     }
   }
   if (keystate[SDL_SCANCODE_S]) {
     if (position_.y + speed_ <= screen_height - height_) {
-      Move(entities::Player::Direction::kDown);
+      Move(Direction::kDown);
     }
   }
   if (keystate[SDL_SCANCODE_D]) {
     if (position_.x + speed_ <= screen_width - width_) {
-      Move(entities::Player::Direction::kRight);
+      Move(Direction::kRight);
     }
   }
 }
@@ -49,28 +51,27 @@ void Player::Render() {
   SDL_RenderCopyF(renderer_, texture_, NULL, &dest_rect_);
 }
 
-int Player::GenerateID() const {
-  static int id = 0;
-  return ++id;
-}
-
 void Player::Move(Direction dir) {
+  math::Vector dir_vec;
   switch (dir) {
     case Direction::kUp:
-      position_.y -= speed_;
+      dir_vec += math::Vector(0.0f, -1.0f);
       break;
     case Direction::kDown:
-      position_.y += speed_;
+      dir_vec += math::Vector(0.0f, 1.0f);
       break;
     case Direction::kLeft:
-      position_.x -= speed_;
+      dir_vec += math::Vector(-1.0f, 0.0f);
       break;
     case Direction::kRight:
-      position_.x += speed_;
+      dir_vec += math::Vector(1.0f, 0.0f);
       break;
     default:
       break;
   }
+  dir_vec = dir_vec.GetUnitVector();
+  position_.x += dir_vec.position_.x * speed_;
+  position_.y += dir_vec.position_.y * speed_;
 }
 
 void Player::UpdateRect() {

--- a/entities/player.cc
+++ b/entities/player.cc
@@ -22,56 +22,39 @@ Player::Player(SDL_Renderer* renderer) {
 
 void Player::HandleMovement(int screen_width, int screen_height) {
   const Uint8* keystate = SDL_GetKeyboardState(NULL);
+  float dir_x = 0.0f;
+  float dir_y = 0.0f;
 
   if (keystate[SDL_SCANCODE_W]) {
     if (position_.y - speed_ >= 0) {
-      Move(Direction::kUp);
+      dir_y += -1.0f;
     }
   }
   if (keystate[SDL_SCANCODE_A]) {
     if (position_.x - speed_ >= 0) {
-      Move(Direction::kLeft);
+      dir_x += -1.0f;
     }
   }
   if (keystate[SDL_SCANCODE_S]) {
     if (position_.y + speed_ <= screen_height - height_) {
-      Move(Direction::kDown);
+      dir_y += 1.0f;
     }
   }
   if (keystate[SDL_SCANCODE_D]) {
     if (position_.x + speed_ <= screen_width - width_) {
-      Move(Direction::kRight);
+      dir_x += 1.0f;
     }
   }
+
+  math::Vector dir_vec = math::Vector(dir_x, dir_y).GetUnitVector();
+  position_.x += dir_vec.position_.x * speed_;
+  position_.y += dir_vec.position_.y * speed_;
 }
 
 void Player::Update() { UpdateRect(); }
 
 void Player::Render() {
   SDL_RenderCopyF(renderer_, texture_, NULL, &dest_rect_);
-}
-
-void Player::Move(Direction dir) {
-  math::Vector dir_vec;
-  switch (dir) {
-    case Direction::kUp:
-      dir_vec += math::Vector(0.0f, -1.0f);
-      break;
-    case Direction::kDown:
-      dir_vec += math::Vector(0.0f, 1.0f);
-      break;
-    case Direction::kLeft:
-      dir_vec += math::Vector(-1.0f, 0.0f);
-      break;
-    case Direction::kRight:
-      dir_vec += math::Vector(1.0f, 0.0f);
-      break;
-    default:
-      break;
-  }
-  dir_vec = dir_vec.GetUnitVector();
-  position_.x += dir_vec.position_.x * speed_;
-  position_.y += dir_vec.position_.y * speed_;
 }
 
 void Player::UpdateRect() {

--- a/entities/player.h
+++ b/entities/player.h
@@ -3,6 +3,7 @@
 
 #include "SDL2/SDL.h"
 #include "entities/entity.h"
+#include "math/vector.h"
 
 namespace entities {
 
@@ -17,8 +18,6 @@ class Player : public Entity {
 
   void Update() override;
   void Render() override;
-
-  void Move(Direction dir) override;
 
  private:
   // Update the position and dimensions of the SDL_Rect.

--- a/entities/player.h
+++ b/entities/player.h
@@ -17,10 +17,8 @@ class Player : public Entity {
 
   void Update() override;
   void Render() override;
-  int GenerateID() const override;
 
-  enum Direction { kNone, kUp, kDown, kLeft, kRight };
-  void Move(Direction dir);
+  void Move(Direction dir) override;
 
  private:
   // Update the position and dimensions of the SDL_Rect.

--- a/entities/player.h
+++ b/entities/player.h
@@ -3,7 +3,6 @@
 
 #include "SDL2/SDL.h"
 #include "entities/entity.h"
-#include "math/vector.h"
 
 namespace entities {
 

--- a/math/vector.cc
+++ b/math/vector.cc
@@ -2,7 +2,6 @@
 
 #include <cmath>
 #include <memory>
-#include <iostream>
 
 #include "SDL2/SDL.h"
 
@@ -73,8 +72,6 @@ Vector Vector::GetUnitVector() const {
   Normalization Formula:
           Unit Vector = Vector / ||Vector|| <- Magnitude
   */
-  std::cout << "[DEBUG] magnitude = " << magnitude_ << " | x = " << position_.x
-            << " | y = " << position_.y << "\n";
   return magnitude_ == 0 ? Vector(0.0f, 0.0f) : *this / magnitude_;
 }
 

--- a/math/vector.cc
+++ b/math/vector.cc
@@ -24,15 +24,32 @@ Vector Vector::operator+(const Vector& vector) const {
                 position_.y + vector.position_.y);
 }
 
+void Vector::operator+=(const Vector& vector) {
+  this->position_.x += vector.position_.x;
+  this->position_.y += vector.position_.y;
+  this->magnitude_ =
+      this->ComputeMagnitude(this->position_.x, this->position_.y);
+}
+
 Vector Vector::operator-(const Vector& vector) const {
   return Vector(position_.x - vector.position_.x,
                 position_.y - vector.position_.y);
 }
 
-Vector Vector::operator/(float num) const { return Vector(position_.x / num, position_.y / num); }
+void Vector::operator-=(const Vector& vector) {
+  this->position_.x -= vector.position_.x;
+  this->position_.y -= vector.position_.y;
+  this->magnitude_ =
+      this->ComputeMagnitude(this->position_.x, this->position_.y);
+}
+
+Vector Vector::operator/(float num) const {
+  return Vector(position_.x / num, position_.y / num);
+}
 
 bool Vector::operator==(const Vector& vector) const {
-  return position_.x == vector.position_.x && position_.y == vector.position_.y && magnitude_ == vector.magnitude_;
+  return position_.x == vector.position_.x &&
+         position_.y == vector.position_.y && magnitude_ == vector.magnitude_;
 }
 
 // Dot Product
@@ -41,11 +58,13 @@ float Vector::operator*(const Vector& vector) const {
 }
 
 float DotProduct(const Vector& vector_a, const Vector& vector_b) {
-  return vector_a.position_.x * vector_b.position_.x + vector_a.position_.y * vector_b.position_.y;
+  return vector_a.position_.x * vector_b.position_.x +
+         vector_a.position_.y * vector_b.position_.y;
 }
 
 float CrossProduct(const Vector& vector_a, const Vector& vector_b) {
-  return vector_a.position_.x * vector_b.position_.y - vector_a.position_.y * vector_b.position_.x;
+  return vector_a.position_.x * vector_b.position_.y -
+         vector_a.position_.y * vector_b.position_.x;
 }
 
 Vector Vector::GetUnitVector() const {
@@ -53,8 +72,7 @@ Vector Vector::GetUnitVector() const {
   Normalization Formula:
           Unit Vector = Vector / ||Vector|| <- Magnitude
   */
-
-  return *this / magnitude_;
+  return magnitude_ == 0 ? Vector(0.0f, 0.0f) : *this / magnitude_;
 }
 
 float Vector::ComputeMagnitude(float x, float y) {

--- a/math/vector.cc
+++ b/math/vector.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <memory>
+#include <iostream>
 
 #include "SDL2/SDL.h"
 
@@ -72,6 +73,8 @@ Vector Vector::GetUnitVector() const {
   Normalization Formula:
           Unit Vector = Vector / ||Vector|| <- Magnitude
   */
+  std::cout << "[DEBUG] magnitude = " << magnitude_ << " | x = " << position_.x
+            << " | y = " << position_.y << "\n";
   return magnitude_ == 0 ? Vector(0.0f, 0.0f) : *this / magnitude_;
 }
 

--- a/math/vector.h
+++ b/math/vector.h
@@ -17,7 +17,9 @@ class Vector {
   Vector(Vector&& vector) = default;
 
   Vector operator+(const Vector& vector) const;
+  void operator+=(const Vector& vector);
   Vector operator-(const Vector& vector) const;
+  void operator-=(const Vector& vector);
   Vector operator/(float num) const;
   float operator*(const Vector& vector) const;  // Dot Product
   bool operator==(const Vector& vector) const;

--- a/math/vector_test.cc
+++ b/math/vector_test.cc
@@ -59,12 +59,31 @@ TEST(VectorTest, Addition) {
   EXPECT_NEAR((vector_a + vector_b).position_.y, 0.2f, 0.01f);
 }
 
+TEST(VectorTest, AdditionAssignment) {
+  Vector vector_a(1.2f, 2.5f);
+  Vector vector_b(2.3f, -2.3f);
+
+  vector_a += vector_b;
+  EXPECT_NEAR(vector_a.position_.x, 3.5f, 0.01f);
+  EXPECT_NEAR(vector_a.position_.y, 0.2f, 0.01f);
+}
+
 TEST(VectorTest, Subtraction) {
   Vector vector_a(1.2f, 2.5f);
   Vector vector_b(2.3f, -2.3f);
 
   EXPECT_NEAR((vector_a - vector_b).position_.x, -1.1f, 0.01f);
   EXPECT_NEAR((vector_a - vector_b).position_.y, 4.8f, 0.01f);
+}
+
+TEST(VectorTest, SubtractionAssignment) {
+  Vector vector_a(1.2f, 2.5f);
+  Vector vector_b(2.3f, -2.3f);
+
+  vector_a -= vector_b;
+
+  EXPECT_NEAR(vector_a.position_.x, -1.1f, 0.01f);
+  EXPECT_NEAR(vector_a.position_.y, 4.8f, 0.01f);
 }
 
 TEST(VectorTest, DotProduct) {
@@ -102,6 +121,16 @@ TEST(VectorTest, UnitVector) {
 
   EXPECT_NEAR(unit_vector.position_.x, 2.0f / std::sqrt(13), 0.01f);
   EXPECT_NEAR(unit_vector.position_.y, 3.0f / std::sqrt(13), 0.01f);
+}
+
+TEST(VectoTest, ComputeMagnitude) {
+  Vector vector(0.0f, 0.0f);
+  vector += Vector(1.0f, 0.0f);
+
+  EXPECT_NEAR(vector.magnitude_, 1.0f, 0.01f)
+      << "x: " << vector.position_.x << "\n"
+      << "y: " << vector.position_.y << "\n"
+      << "magnitude: " << vector.magnitude_ << "\n";
 }
 
 }  // namespace


### PR DESCRIPTION
Currently, if the player moves diagonally, they move faster than if the movement is just vertical or horizontal because the direction * speed is not normalized. In this PR, the player movement implementation has been changed to use vectors in order to allow for vector normalization.

FIxes #14 