### PR TITLE
Added `util` function for reading in `.txt` files into protobuf messages.

### DIFF
--- a/util/BUILD
+++ b/util/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "proto",
+    srcs = ["proto.cc"],
+    hdrs = ["proto.h"],
+    deps = [
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_test(
+    name = "proto_test",
+    srcs = ["proto_test.cc"],
+    data = ["//util/testdata:test_txt"],
+    deps = [
+        ":proto",
+        "//util/testdata:test_cc_proto",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/util/proto.cc
+++ b/util/proto.cc
@@ -1,0 +1,25 @@
+#include "util/proto.h"
+
+#include <fcntl.h>
+
+#include "absl/log/check.h"
+#include "absl/strings/match.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/text_format.h"
+
+namespace util {
+namespace proto {
+
+void ReadTextProto(google::protobuf::Message* message,
+                   absl::string_view textproto_path) {
+  CHECK_EQ(absl::EndsWith(textproto_path, ".txt"), true)
+      << "File extension must be .txt.";
+  int file_descriptor = open(textproto_path.data(), O_RDONLY);
+  google::protobuf::io::FileInputStream finput(file_descriptor);
+  finput.SetCloseOnDelete(true);
+  bool success = google::protobuf::TextFormat::Parse(&finput, message);
+  CHECK_EQ(success, true) << "Failed to parse .txt into proto message.";
+}
+
+}  // namespace proto
+}  // namespace util

--- a/util/proto.h
+++ b/util/proto.h
@@ -1,0 +1,17 @@
+#ifndef UTIL_PROTO_
+#define UTIL_PROTO_
+
+#include "absl/strings/string_view.h"
+#include "google/protobuf/message.h"
+
+namespace util {
+namespace proto {
+
+// Reads `.txt` file into a protobuf message.
+void ReadTextProto(google::protobuf::Message* message,
+                   absl::string_view textproto_path);
+
+}  // namespace proto
+}  // namespace util
+
+#endif

--- a/util/proto_test.cc
+++ b/util/proto_test.cc
@@ -1,0 +1,26 @@
+#include "util/proto.h"
+
+#include "gtest/gtest.h"
+#include "util/testdata/test.pb.h"
+
+namespace util {
+namespace proto {
+namespace {
+
+TEST(ProtoUtilTest, ReadTextProto) {
+  ::util::Test test;
+
+  ReadTextProto(&test, "util/testdata/test.txt");
+
+  EXPECT_EQ(test.id(), 123);
+}
+
+TEST(ProtoUtilTest, FailReadTextProto) {
+  ::util::Test test;
+
+  EXPECT_DEATH(ReadTextProto(&test, "util/testdata/test.textproto"), "File extension must be .txt.");
+}
+
+}  // namespace
+}  // namespace proto
+}  // namespace util

--- a/util/testdata/BUILD
+++ b/util/testdata/BUILD
@@ -1,0 +1,21 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//util:__subpackages__"])
+
+filegroup(
+    name = "test_txt",
+    srcs = [
+        "test.txt",
+    ],
+)
+
+proto_library(
+    name = "test_proto",
+    srcs = ["test.proto"],
+)
+
+cc_proto_library(
+    name = "test_cc_proto",
+    deps = [":test_proto"],
+)

--- a/util/testdata/test.proto
+++ b/util/testdata/test.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+package util;
+
+message Test {
+  optional int32 id = 1;
+}

--- a/util/testdata/test.txt
+++ b/util/testdata/test.txt
@@ -1,0 +1,4 @@
+# proto-file: util/testdata/test.proto
+# proto-message: util.Test
+
+id: 123


### PR DESCRIPTION
This util function can be used to parse in `.txt` files into protobuf messages.