### PR TITLE
Remove `.bazelrc`.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,0 @@
-build --cxxopt="-std=c++20"


### PR DESCRIPTION
The `.bazelrc` file should not be the same for every developer (to take into account compatibility issues).